### PR TITLE
Fix error with HTML templates embedded in `script` tag

### DIFF
--- a/tests/HtmlMatcherTest.php
+++ b/tests/HtmlMatcherTest.php
@@ -58,4 +58,53 @@ class HtmlMatcherTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
+    /**
+     * @test
+     */
+    public function considersValidHtml_WHtmlContainsScriptTagWithHtmlContents()
+    {
+        $html = "<div>
+<script type='x-template'>
+	<span></span>
+</script>
+</div>";
+
+        assertThat($html, is(HtmlMatcher::htmlPiece()));
+    }
+
+    /**
+     * @test
+     */
+    public function addsSpecificTextInsideTheSciptTagsInsteadOfItsContents()
+    {
+        $html = "<div>
+<script type='x-template'>
+	<span></span>
+</script>
+</div>";
+
+        assertThat($html, is(htmlPiece(havingChild(
+            both(withTagName('script'))
+                ->andAlso(havingTextContents(HtmlMatcher::SCRIPT_BODY_REPLACEMENT))))));
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotTouchScriptTagAttributes()
+    {
+        $html = "<div>
+<script type='x-template' attr1='value1'>
+	<span></span>
+</script>
+</div>";
+
+        assertThat($html, is(htmlPiece(havingChild(
+            allOf(
+                withTagName('script'),
+                withAttribute('type')->havingValue('x-template'),
+                withAttribute('attr1')->havingValue('value1')
+            )))));
+    }
+
 }


### PR DESCRIPTION
The issue was that if given HTML contains `script` tag containing any closing tag in anywhere (even in JS string literal) then assertions were failing. Reason for that is `DOMDocument` implementation.
These were failing:
```html
<div>
<script type='x-template'>
	<span></span>
</script>
</div>
```

```html
<div>
<script>
	'</span>'
</script>
</div>
```

Solution is to strip out script tags' contents before parsing leaving note that those were stripped.