### PR TITLE
Fix travis config to run on HHVM again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: trusty
 php:
   - 5.5
   - 5.6


### PR DESCRIPTION
Travis error: 
```
HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
```