### PR TITLE
Add PHPCS checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "hamcrest/hamcrest-php": "^1.1.1||^2.0"
     },
     "require-dev": {
+        "wikibase/wikibase-codesniffer": "^0.1.0",
         "phpunit/phpunit": "^4.8"
     },
     "autoload": {
@@ -31,6 +32,7 @@
     },
     "scripts": {
         "ci": [
+            "phpcs -p -s",
             "phpunit"
         ]
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="HamcrestHtmlMatchers">
+	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
+		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
+		<exclude name="Generic.PHP.NoSilencedErrors" />
+		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis" />
+	</rule>
+
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="128" />
+		</properties>
+	</rule>
+
+	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
+		<exclude-pattern>functions\.php</exclude-pattern>
+	</rule>
+
+	<file>.</file>
+</ruleset>

--- a/src/AttributeMatcher.php
+++ b/src/AttributeMatcher.php
@@ -8,6 +8,7 @@ use Hamcrest\Util;
 
 class AttributeMatcher extends TagMatcher
 {
+
     /**
      * @var Matcher
      */
@@ -82,4 +83,5 @@ class AttributeMatcher extends TagMatcher
 
         return false;
     }
+
 }

--- a/src/ChildElementMatcher.php
+++ b/src/ChildElementMatcher.php
@@ -8,6 +8,7 @@ use Hamcrest\TypeSafeDiagnosingMatcher;
 
 class ChildElementMatcher extends TypeSafeDiagnosingMatcher
 {
+
     /**
      * @var Matcher|null
      */
@@ -66,4 +67,5 @@ class ChildElementMatcher extends TypeSafeDiagnosingMatcher
         $mismatchDescription->appendText('having no children ')->appendDescriptionOf($this->matcher);
         return false;
     }
+
 }

--- a/src/ClassMatcher.php
+++ b/src/ClassMatcher.php
@@ -8,6 +8,7 @@ use Hamcrest\Util;
 
 class ClassMatcher extends TagMatcher
 {
+
     /**
      * @var Matcher
      */
@@ -47,4 +48,5 @@ class ClassMatcher extends TagMatcher
 
         return false;
     }
+
 }

--- a/src/ComplexTagMatcher.php
+++ b/src/ComplexTagMatcher.php
@@ -10,6 +10,7 @@ use Hamcrest\Matcher;
 
 class ComplexTagMatcher extends TagMatcher
 {
+
     /**
      * @link http://www.xmlsoft.org/html/libxml-xmlerror.html#xmlParserErrors
      * @link https://github.com/Chronic-Dev/libxml2/blob/683f296a905710ff285c28b8644ef3a3d8be9486/include/libxml/xmlerror.h#L257
@@ -205,4 +206,5 @@ class ComplexTagMatcher extends TagMatcher
         $newDocument->appendChild($newDocument->importNode($cloned, true));
         return trim($newDocument->saveHTML());
     }
+
 }

--- a/src/DirectChildElementMatcher.php
+++ b/src/DirectChildElementMatcher.php
@@ -2,13 +2,13 @@
 
 namespace WMDE\HamcrestHtml;
 
-
 use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\TypeSafeDiagnosingMatcher;
 
 class DirectChildElementMatcher extends TypeSafeDiagnosingMatcher
 {
+
     /**
      * @var Matcher
      */
@@ -72,4 +72,5 @@ class DirectChildElementMatcher extends TypeSafeDiagnosingMatcher
 
         return false;
     }
+
 }

--- a/src/HtmlMatcher.php
+++ b/src/HtmlMatcher.php
@@ -8,6 +8,7 @@ use Hamcrest\Matcher;
 
 class HtmlMatcher extends DiagnosingMatcher
 {
+
 	/**
      * @link http://www.xmlsoft.org/html/libxml-xmlerror.html#xmlParserErrors
      * @link https://github.com/Chronic-Dev/libxml2/blob/683f296a905710ff285c28b8644ef3a3d8be9486/include/libxml/xmlerror.h#L257
@@ -108,4 +109,5 @@ class HtmlMatcher extends DiagnosingMatcher
         }
         return $html;
     }
+
 }

--- a/src/RootElementMatcher.php
+++ b/src/RootElementMatcher.php
@@ -8,6 +8,7 @@ use Hamcrest\TypeSafeDiagnosingMatcher;
 
 class RootElementMatcher extends TypeSafeDiagnosingMatcher
 {
+
     /**
      * @var Matcher
      */
@@ -68,4 +69,5 @@ class RootElementMatcher extends TypeSafeDiagnosingMatcher
 
         return (bool)$target;
     }
+
 }

--- a/src/TagMatcher.php
+++ b/src/TagMatcher.php
@@ -6,8 +6,10 @@ use Hamcrest\TypeSafeDiagnosingMatcher;
 
 abstract class TagMatcher extends TypeSafeDiagnosingMatcher
 {
+
     public function __construct()
     {
         parent::__construct(self::TYPE_OBJECT, \DOMElement::class);
     }
+
 }

--- a/src/TagNameMatcher.php
+++ b/src/TagNameMatcher.php
@@ -8,6 +8,7 @@ use Hamcrest\Util;
 
 class TagNameMatcher extends TagMatcher
 {
+
     /**
      * @var Matcher
      */
@@ -41,4 +42,5 @@ class TagNameMatcher extends TagMatcher
         $this->tagNameMatcher->describeMismatch($item->tagName, $mismatchDescription);
         return $this->tagNameMatcher->matches($item->tagName);
     }
+
 }

--- a/src/TextContentsMatcher.php
+++ b/src/TextContentsMatcher.php
@@ -1,12 +1,14 @@
 <?php
 
 namespace WMDE\HamcrestHtml;
+
 use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\Util;
 
 class TextContentsMatcher extends TagMatcher
 {
+
     /**
      * @var Matcher
      */
@@ -37,4 +39,5 @@ class TextContentsMatcher extends TagMatcher
     {
         return $this->matcher->matches($item->textContent);
     }
+
 }

--- a/src/XmlNodeRecursiveIterator.php
+++ b/src/XmlNodeRecursiveIterator.php
@@ -2,9 +2,9 @@
 
 namespace WMDE\HamcrestHtml;
 
-
 class XmlNodeRecursiveIterator extends \ArrayIterator
 {
+
     public function __construct(\DOMNodeList $nodeList)
     {
         $queue = $this->addElementsToQueue([], $nodeList);
@@ -29,4 +29,5 @@ class XmlNodeRecursiveIterator extends \ArrayIterator
 
         return $queue;
     }
+
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,4 +1,5 @@
 <?php
+
 use Hamcrest\Matcher;
 
 if (!function_exists('htmlPiece')) {

--- a/tests/ComplexTagMatcherTest.php
+++ b/tests/ComplexTagMatcherTest.php
@@ -10,6 +10,7 @@ use WMDE\HamcrestHtml\ComplexTagMatcher;
  */
 class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
      * @test
      */
@@ -136,4 +137,5 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
         assertThat($html, is(htmlPiece(havingChild(
             ComplexTagMatcher::tagMatchingOutline('<input class="   class1   "/>')))));
     }
+
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -7,6 +7,7 @@ use Hamcrest\Matcher;
 
 class FunctionsTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
      * @test
      */
@@ -197,4 +198,5 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
             ],
         ];
     }
+
 }

--- a/tests/HtmlMatcherTest.php
+++ b/tests/HtmlMatcherTest.php
@@ -9,6 +9,7 @@ use WMDE\HamcrestHtml\HtmlMatcher;
  */
 class HtmlMatcherTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
      * @test
      * @dataProvider dataProvider_HtmlTagNamesIntroducedInHtml5

--- a/tests/XmlNodeRecursiveIteratorTest.php
+++ b/tests/XmlNodeRecursiveIteratorTest.php
@@ -9,6 +9,7 @@ use WMDE\HamcrestHtml\XmlNodeRecursiveIterator;
  */
 class XmlNodeRecursiveIteratorTest extends \PHPUnit_Framework_TestCase
 {
+
     public function testIteratesAllElements_WhenFlatStructureGiven()
     {
         $DOMNodeList = $this->createDomNodeListFromHtml('<p></p>');
@@ -58,4 +59,5 @@ class XmlNodeRecursiveIteratorTest extends \PHPUnit_Framework_TestCase
         }, $array);
         return $tagNames;
     }
+
 }


### PR DESCRIPTION
I decided to go with the Wikibase rule set. I'm aware the current code formatting follows what Hamcrest does. I suggest to change this, and follow the MediaWiki standard (with spaces inside brackets, and the opening `{` at the end of the line).