### PR TITLE
Update PHP code formatting to be more like the MediaWiki standard

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="HamcrestHtmlMatchers">
 	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
-		<exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
 		<exclude name="Generic.PHP.NoSilencedErrors" />
 		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent" />
-		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis" />
 	</rule>
 
 	<rule ref="Generic.Files.LineLength">

--- a/src/AttributeMatcher.php
+++ b/src/AttributeMatcher.php
@@ -6,8 +6,7 @@ use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\Util;
 
-class AttributeMatcher extends TagMatcher
-{
+class AttributeMatcher extends TagMatcher {
 
     /**
      * @var Matcher
@@ -19,16 +18,15 @@ class AttributeMatcher extends TagMatcher
      */
     private $valueMatcher;
 
-    public static function withAttribute($attributeName) {
-        return new static(Util::wrapValueWithIsEqual($attributeName));
+    public static function withAttribute( $attributeName ) {
+        return new static( Util::wrapValueWithIsEqual( $attributeName ) );
     }
 
     /**
      * AttributeMatcher constructor.
      * @param \Hamcrest\Matcher $attributeNameMatcher
      */
-    public function __construct(Matcher $attributeNameMatcher)
-    {
+    public function __construct( Matcher $attributeNameMatcher ) {
         parent::__construct();
 
         $this->attributeNameMatcher = $attributeNameMatcher;
@@ -38,22 +36,20 @@ class AttributeMatcher extends TagMatcher
      * @param Matcher|mixed $value
      * @return AttributeMatcher
      */
-    public function havingValue($value)
-    {
+    public function havingValue( $value ) {
         //TODO: Throw exception if value is set
         $result = clone $this;
-        $result->valueMatcher = Util::wrapValueWithIsEqual($value);
+        $result->valueMatcher = Util::wrapValueWithIsEqual( $value );
 
         return $result;
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('with attribute ')
-            ->appendDescriptionOf($this->attributeNameMatcher);
-        if ($this->valueMatcher) {
-            $description->appendText(' having value ')
-                ->appendDescriptionOf($this->valueMatcher);
+    public function describeTo( Description $description ) {
+        $description->appendText( 'with attribute ' )
+            ->appendDescriptionOf( $this->attributeNameMatcher );
+        if ( $this->valueMatcher ) {
+            $description->appendText( ' having value ' )
+                ->appendDescriptionOf( $this->valueMatcher );
         }
     }
 
@@ -63,19 +59,18 @@ class AttributeMatcher extends TagMatcher
      *
      * @return bool
      */
-    protected function matchesSafelyWithDiagnosticDescription($item, Description $mismatchDescription)
-    {
+    protected function matchesSafelyWithDiagnosticDescription( $item, Description $mismatchDescription ) {
         /** @var \DOMAttr $attribute */
-        foreach ($item->attributes as $attribute) {
-            if ($this->valueMatcher) {
+        foreach ( $item->attributes as $attribute ) {
+            if ( $this->valueMatcher ) {
                 if (
-                    $this->attributeNameMatcher->matches($attribute->name)
-                    && $this->valueMatcher->matches($attribute->value)
+                    $this->attributeNameMatcher->matches( $attribute->name )
+                    && $this->valueMatcher->matches( $attribute->value )
                 ) {
                     return true;
                 }
             } else {
-                if ($this->attributeNameMatcher->matches($attribute->name)) {
+                if ( $this->attributeNameMatcher->matches( $attribute->name ) ) {
                     return true;
                 }
             }

--- a/src/ChildElementMatcher.php
+++ b/src/ChildElementMatcher.php
@@ -6,29 +6,26 @@ use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\TypeSafeDiagnosingMatcher;
 
-class ChildElementMatcher extends TypeSafeDiagnosingMatcher
-{
+class ChildElementMatcher extends TypeSafeDiagnosingMatcher {
 
     /**
      * @var Matcher|null
      */
     private $matcher;
 
-    public static function havingChild(Matcher $elementMatcher = null) {
-        return new static($elementMatcher);
+    public static function havingChild( Matcher $elementMatcher = null ) {
+        return new static( $elementMatcher );
     }
 
-    public function __construct(Matcher $matcher = null)
-    {
-        parent::__construct(\DOMNode::class);
+    public function __construct( Matcher $matcher = null ) {
+        parent::__construct( \DOMNode::class );
         $this->matcher = $matcher;
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('having child ');
-        if ($this->matcher) {
-            $description->appendDescriptionOf($this->matcher);
+    public function describeTo( Description $description ) {
+        $description->appendText( 'having child ' );
+        if ( $this->matcher ) {
+            $description->appendDescriptionOf( $this->matcher );
         }
     }
 
@@ -38,33 +35,32 @@ class ChildElementMatcher extends TypeSafeDiagnosingMatcher
      *
      * @return bool
      */
-    protected function matchesSafelyWithDiagnosticDescription($item, Description $mismatchDescription)
-    {
-        if ($item instanceof \DOMDocument) {
-            $directChildren = iterator_to_array($item->documentElement->childNodes);
+    protected function matchesSafelyWithDiagnosticDescription( $item, Description $mismatchDescription ) {
+        if ( $item instanceof \DOMDocument ) {
+            $directChildren = iterator_to_array( $item->documentElement->childNodes );
 
-            $body = array_shift($directChildren);
+            $body = array_shift( $directChildren );
             $directChildren = $body->childNodes;
         } else {
             $directChildren = $item->childNodes;
         }
 
-        if ($directChildren->length === 0) {
-            $mismatchDescription->appendText('having no children');
+        if ( $directChildren->length === 0 ) {
+            $mismatchDescription->appendText( 'having no children' );
             return false;
         }
 
-        if (!$this->matcher) {
+        if ( !$this->matcher ) {
             return $directChildren->length > 0;
         }
 
-        foreach (new XmlNodeRecursiveIterator($directChildren) as $child) {
-            if ($this->matcher && $this->matcher->matches($child)) {
+        foreach ( new XmlNodeRecursiveIterator( $directChildren ) as $child ) {
+            if ( $this->matcher && $this->matcher->matches( $child ) ) {
                 return true;
             }
         }
 
-        $mismatchDescription->appendText('having no children ')->appendDescriptionOf($this->matcher);
+        $mismatchDescription->appendText( 'having no children ' )->appendDescriptionOf( $this->matcher );
         return false;
     }
 

--- a/src/ClassMatcher.php
+++ b/src/ClassMatcher.php
@@ -6,27 +6,24 @@ use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\Util;
 
-class ClassMatcher extends TagMatcher
-{
+class ClassMatcher extends TagMatcher {
 
     /**
      * @var Matcher
      */
     private $classMatcher;
 
-    public static function withClass($class) {
-        return new static(Util::wrapValueWithIsEqual($class));
+    public static function withClass( $class ) {
+        return new static( Util::wrapValueWithIsEqual( $class ) );
     }
 
-    public function __construct(Matcher $class)
-    {
+    public function __construct( Matcher $class ) {
         parent::__construct();
         $this->classMatcher = $class;
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('with class ')->appendDescriptionOf($this->classMatcher);
+    public function describeTo( Description $description ) {
+        $description->appendText( 'with class ' )->appendDescriptionOf( $this->classMatcher );
     }
 
     /**
@@ -35,13 +32,12 @@ class ClassMatcher extends TagMatcher
      *
      * @return bool
      */
-    protected function matchesSafelyWithDiagnosticDescription($item, Description $mismatchDescription)
-    {
-        $classAttribute = $item->getAttribute('class');
+    protected function matchesSafelyWithDiagnosticDescription( $item, Description $mismatchDescription ) {
+        $classAttribute = $item->getAttribute( 'class' );
 
-        $classes = preg_split('/\s+/u', $classAttribute);
-        foreach ($classes as $class) {
-            if ($this->classMatcher->matches($class)) {
+        $classes = preg_split( '/\s+/u', $classAttribute );
+        foreach ( $classes as $class ) {
+            if ( $this->classMatcher->matches( $class ) ) {
                 return true;
             }
         }

--- a/src/ComplexTagMatcher.php
+++ b/src/ComplexTagMatcher.php
@@ -8,8 +8,7 @@ use InvalidArgumentException;
 use Hamcrest\Description;
 use Hamcrest\Matcher;
 
-class ComplexTagMatcher extends TagMatcher
-{
+class ComplexTagMatcher extends TagMatcher {
 
     /**
      * @link http://www.xmlsoft.org/html/libxml-xmlerror.html#xmlParserErrors
@@ -31,24 +30,21 @@ class ComplexTagMatcher extends TagMatcher
      * @param string $htmlOutline
      * @return self
      */
-    public static function tagMatchingOutline($htmlOutline)
-    {
-        return new self($htmlOutline);
+    public static function tagMatchingOutline( $htmlOutline ) {
+        return new self( $htmlOutline );
     }
 
-    public function __construct($tagHtmlRepresentation)
-    {
+    public function __construct( $tagHtmlRepresentation ) {
         parent::__construct();
 
         $this->tagHtmlOutline = $tagHtmlRepresentation;
-        $this->matcher = $this->createMatcherFromHtml($tagHtmlRepresentation);
+        $this->matcher = $this->createMatcherFromHtml( $tagHtmlRepresentation );
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('tag matching outline `')
-            ->appendText($this->tagHtmlOutline)
-            ->appendText('` ');
+    public function describeTo( Description $description ) {
+        $description->appendText( 'tag matching outline `' )
+            ->appendText( $this->tagHtmlOutline )
+            ->appendText( '` ' );
     }
 
     /**
@@ -57,44 +53,40 @@ class ComplexTagMatcher extends TagMatcher
      *
      * @return bool
      */
-    protected function matchesSafelyWithDiagnosticDescription($item, Description $mismatchDescription)
-    {
-        $result = $this->matcher->matches($item);
-        if (!$result) {
-            $mismatchDescription->appendText('was `')
-                ->appendText($this->elementToString($item))
-                ->appendText('`');
+    protected function matchesSafelyWithDiagnosticDescription( $item, Description $mismatchDescription ) {
+        $result = $this->matcher->matches( $item );
+        if ( !$result ) {
+            $mismatchDescription->appendText( 'was `' )
+                ->appendText( $this->elementToString( $item ) )
+                ->appendText( '`' );
         }
         return $result;
     }
 
-    private function createMatcherFromHtml($htmlOutline)
-    {
-        $document = $this->parseHtml($htmlOutline);
-        $targetTag = $this->getSingleTagFromThe($document);
+    private function createMatcherFromHtml( $htmlOutline ) {
+        $document = $this->parseHtml( $htmlOutline );
+        $targetTag = $this->getSingleTagFromThe( $document );
 
-        $this->assertTagDoesNotContainChildren($targetTag);
+        $this->assertTagDoesNotContainChildren( $targetTag );
 
-        $attributeMatchers = $this->createAttributeMatchers($htmlOutline, $targetTag);
-        $classMatchers = $this->createClassMatchers($targetTag);
+        $attributeMatchers = $this->createAttributeMatchers( $htmlOutline, $targetTag );
+        $classMatchers = $this->createClassMatchers( $targetTag );
 
         return AllOf::allOf(
-            new TagNameMatcher(IsEqual::equalTo($targetTag->tagName)),
-            call_user_func_array([AllOf::class, 'allOf'], $attributeMatchers),
-            call_user_func_array([AllOf::class, 'allOf'], $classMatchers)
+            new TagNameMatcher( IsEqual::equalTo( $targetTag->tagName ) ),
+            call_user_func_array( [ AllOf::class, 'allOf' ], $attributeMatchers ),
+            call_user_func_array( [ AllOf::class, 'allOf' ], $classMatchers )
         );
     }
 
-    private function isUnknownTagError(\LibXMLError $error)
-    {
+    private function isUnknownTagError( \LibXMLError $error ) {
         return $error->code === self::XML_UNKNOWN_TAG_ERROR_CODE;
     }
 
-    private function isBooleanAttribute($inputHtml, $attributeName)
-    {
-        $quotedName = preg_quote($attributeName, '/');
+    private function isBooleanAttribute( $inputHtml, $attributeName ) {
+        $quotedName = preg_quote( $attributeName, '/' );
 
-        $attributeHasValueAssigned = preg_match("/\b{$quotedName}\s*=/ui", $inputHtml);
+        $attributeHasValueAssigned = preg_match( "/\b{$quotedName}\s*=/ui", $inputHtml );
         return !$attributeHasValueAssigned;
     }
 
@@ -104,27 +96,26 @@ class ComplexTagMatcher extends TagMatcher
      * @return \DOMDocument
      * @throws \InvalidArgumentException
      */
-    private function parseHtml($html)
-    {
-        $internalErrors = libxml_use_internal_errors(true);
+    private function parseHtml( $html ) {
+        $internalErrors = libxml_use_internal_errors( true );
         $document = new \DOMDocument();
 
-        if (!@$document->loadHTML($html)) {
-            throw new \InvalidArgumentException("There was some parsing error of `$html`");
+        if ( !@$document->loadHTML( $html ) ) {
+            throw new \InvalidArgumentException( "There was some parsing error of `$html`" );
         }
 
         $errors = libxml_get_errors();
         libxml_clear_errors();
-        libxml_use_internal_errors($internalErrors);
+        libxml_use_internal_errors( $internalErrors );
 
         /** @var \LibXMLError $error */
-        foreach ($errors as $error) {
-            if ($this->isUnknownTagError($error)) {
+        foreach ( $errors as $error ) {
+            if ( $this->isUnknownTagError( $error ) ) {
                 continue;
             }
 
             throw new \InvalidArgumentException(
-                'There was parsing error: ' . trim($error->message) . ' on line ' . $error->line
+                'There was parsing error: ' . trim( $error->message ) . ' on line ' . $error->line
             );
         }
 
@@ -137,24 +128,22 @@ class ComplexTagMatcher extends TagMatcher
      * @return \DOMElement
      * @throws \InvalidArgumentException
      */
-    private function getSingleTagFromThe(\DOMDocument $document)
-    {
-        $directChildren = iterator_to_array($document->documentElement->childNodes);
+    private function getSingleTagFromThe( \DOMDocument $document ) {
+        $directChildren = iterator_to_array( $document->documentElement->childNodes );
 
-        $body = array_shift($directChildren);
-        $directChildren = iterator_to_array($body->childNodes);
+        $body = array_shift( $directChildren );
+        $directChildren = iterator_to_array( $body->childNodes );
 
-        if (count($directChildren) !== 1) {
-            throw new InvalidArgumentException('Expected exactly 1 tag description, got ' . count($directChildren));
+        if ( count( $directChildren ) !== 1 ) {
+            throw new InvalidArgumentException( 'Expected exactly 1 tag description, got ' . count( $directChildren ) );
         }
 
         return $directChildren[0];
     }
 
-    private function assertTagDoesNotContainChildren(\DOMElement $targetTag)
-    {
-        if ($targetTag->childNodes->length > 0) {
-            throw new InvalidArgumentException('Nested elements are not allowed');
+    private function assertTagDoesNotContainChildren( \DOMElement $targetTag ) {
+        if ( $targetTag->childNodes->length > 0 ) {
+            throw new InvalidArgumentException( 'Nested elements are not allowed' );
         }
     }
 
@@ -163,18 +152,17 @@ class ComplexTagMatcher extends TagMatcher
      * @param $targetTag
      * @return AttributeMatcher[]
      */
-    private function createAttributeMatchers($inputHtml, \DOMElement $targetTag)
-    {
+    private function createAttributeMatchers( $inputHtml, \DOMElement $targetTag ) {
         $attributeMatchers = [];
         /** @var \DOMAttr $attribute */
-        foreach ($targetTag->attributes as $attribute) {
-            if ($attribute->name === 'class') {
+        foreach ( $targetTag->attributes as $attribute ) {
+            if ( $attribute->name === 'class' ) {
                 continue;
             }
 
-            $attributeMatcher = new AttributeMatcher(IsEqual::equalTo($attribute->name));
-            if (!$this->isBooleanAttribute($inputHtml, $attribute->name)) {
-                $attributeMatcher = $attributeMatcher->havingValue(IsEqual::equalTo($attribute->value));
+            $attributeMatcher = new AttributeMatcher( IsEqual::equalTo( $attribute->name ) );
+            if ( !$this->isBooleanAttribute( $inputHtml, $attribute->name ) ) {
+                $attributeMatcher = $attributeMatcher->havingValue( IsEqual::equalTo( $attribute->value ) );
             }
 
             $attributeMatchers[] = $attributeMatcher;
@@ -186,25 +174,23 @@ class ComplexTagMatcher extends TagMatcher
      * @param \DOMElement $targetTag
      * @return ClassMatcher[]
      */
-    private function createClassMatchers($targetTag)
-    {
+    private function createClassMatchers( $targetTag ) {
         $classMatchers = [];
-        $classValue = $targetTag->getAttribute('class');
-        foreach (explode(' ', $classValue) as $expectedClass) {
-            if ($expectedClass === '') {
+        $classValue = $targetTag->getAttribute( 'class' );
+        foreach ( explode( ' ', $classValue ) as $expectedClass ) {
+            if ( $expectedClass === '' ) {
                 continue;
             }
-            $classMatchers[] = new ClassMatcher(IsEqual::equalTo($expectedClass));
+            $classMatchers[] = new ClassMatcher( IsEqual::equalTo( $expectedClass ) );
         }
         return $classMatchers;
     }
 
-    private function elementToString(\DOMElement $element)
-    {
+    private function elementToString( \DOMElement $element ) {
         $newDocument = new \DOMDocument();
-        $cloned = $element->cloneNode(true);
-        $newDocument->appendChild($newDocument->importNode($cloned, true));
-        return trim($newDocument->saveHTML());
+        $cloned = $element->cloneNode( true );
+        $newDocument->appendChild( $newDocument->importNode( $cloned, true ) );
+        return trim( $newDocument->saveHTML() );
     }
 
 }

--- a/src/DirectChildElementMatcher.php
+++ b/src/DirectChildElementMatcher.php
@@ -6,29 +6,26 @@ use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\TypeSafeDiagnosingMatcher;
 
-class DirectChildElementMatcher extends TypeSafeDiagnosingMatcher
-{
+class DirectChildElementMatcher extends TypeSafeDiagnosingMatcher {
 
     /**
      * @var Matcher
      */
     private $matcher;
 
-    public static function havingDirectChild(Matcher $elementMatcher = null) {
-        return new static($elementMatcher);
+    public static function havingDirectChild( Matcher $elementMatcher = null ) {
+        return new static( $elementMatcher );
     }
 
-    public function __construct(Matcher $matcher = null)
-    {
-        parent::__construct(\DOMNode::class);
+    public function __construct( Matcher $matcher = null ) {
+        parent::__construct( \DOMNode::class );
         $this->matcher = $matcher;
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('having direct child ');
-        if ($this->matcher) {
-            $description->appendDescriptionOf($this->matcher);
+    public function describeTo( Description $description ) {
+        $description->appendText( 'having direct child ' );
+        if ( $this->matcher ) {
+            $description->appendDescriptionOf( $this->matcher );
         }
     }
 
@@ -38,37 +35,36 @@ class DirectChildElementMatcher extends TypeSafeDiagnosingMatcher
      *
      * @return bool
      */
-    protected function matchesSafelyWithDiagnosticDescription($item, Description $mismatchDescription)
-    {
-        if ($item instanceof \DOMDocument) {
-            $directChildren = iterator_to_array($item->documentElement->childNodes);
+    protected function matchesSafelyWithDiagnosticDescription( $item, Description $mismatchDescription ) {
+        if ( $item instanceof \DOMDocument ) {
+            $directChildren = iterator_to_array( $item->documentElement->childNodes );
 
-            $body = array_shift($directChildren);
+            $body = array_shift( $directChildren );
             $directChildren = $body->childNodes;
         } else {
             $directChildren = $item->childNodes;
         }
 
-        if ($directChildren->length === 0) {
-            $mismatchDescription->appendText('with no direct children');
+        if ( $directChildren->length === 0 ) {
+            $mismatchDescription->appendText( 'with no direct children' );
             return false;
         }
 
         $childWord = $directChildren->length === 1 ? 'child' : 'children';
 
-        $mismatchDescription->appendText("with direct {$childWord} ");
+        $mismatchDescription->appendText( "with direct {$childWord} " );
 
-        if (!$this->matcher) {
-            return count($directChildren) !== 0;
+        if ( !$this->matcher ) {
+            return count( $directChildren ) !== 0;
         }
 
-        foreach ($directChildren as $child) {
-            if ($this->matcher && $this->matcher->matches($child)) {
+        foreach ( $directChildren as $child ) {
+            if ( $this->matcher && $this->matcher->matches( $child ) ) {
                 return true;
             }
         }
 
-        $this->matcher->describeMismatch($child, $mismatchDescription);
+        $this->matcher->describeMismatch( $child, $mismatchDescription );
 
         return false;
     }

--- a/src/HtmlMatcher.php
+++ b/src/HtmlMatcher.php
@@ -6,10 +6,9 @@ use Hamcrest\Description;
 use Hamcrest\DiagnosingMatcher;
 use Hamcrest\Matcher;
 
-class HtmlMatcher extends DiagnosingMatcher
-{
+class HtmlMatcher extends DiagnosingMatcher {
 
-	/**
+    /**
      * @link http://www.xmlsoft.org/html/libxml-xmlerror.html#xmlParserErrors
      * @link https://github.com/Chronic-Dev/libxml2/blob/683f296a905710ff285c28b8644ef3a3d8be9486/include/libxml/xmlerror.h#L257
      */
@@ -25,71 +24,66 @@ class HtmlMatcher extends DiagnosingMatcher
      *
      * @return HtmlMatcher
      */
-    public static function htmlPiece(Matcher $elementMatcher = null)
-    {
-        return new static($elementMatcher);
+    public static function htmlPiece( Matcher $elementMatcher = null ) {
+        return new static( $elementMatcher );
     }
 
-    private function __construct(Matcher $elementMatcher = null)
-    {
+    private function __construct( Matcher $elementMatcher = null ) {
         $this->elementMatcher = $elementMatcher;
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('valid html piece ');
-        if ($this->elementMatcher) {
-            $description->appendDescriptionOf($this->elementMatcher);
+    public function describeTo( Description $description ) {
+        $description->appendText( 'valid html piece ' );
+        if ( $this->elementMatcher ) {
+            $description->appendDescriptionOf( $this->elementMatcher );
         }
     }
 
-    protected function matchesWithDiagnosticDescription($html, Description $mismatchDescription)
-    {
-        $internalErrors = libxml_use_internal_errors(true);
+    protected function matchesWithDiagnosticDescription( $html, Description $mismatchDescription ) {
+        $internalErrors = libxml_use_internal_errors( true );
         $document = new \DOMDocument();
 
-        $html = $this->escapeScriptTagContents($html);
+        $html = $this->escapeScriptTagContents( $html );
 
-        if (!@$document->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'))) {
-            $mismatchDescription->appendText('there was some parsing error');
+        if ( !@$document->loadHTML( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ) ) ) {
+            $mismatchDescription->appendText( 'there was some parsing error' );
             return false;
         }
 
         $errors = libxml_get_errors();
         libxml_clear_errors();
-        libxml_use_internal_errors($internalErrors);
+        libxml_use_internal_errors( $internalErrors );
 
         $result = true;
         /** @var \LibXMLError $error */
-        foreach ($errors as $error) {
-            if ($this->isUnknownTagError($error)) {
+        foreach ( $errors as $error ) {
+            if ( $this->isUnknownTagError( $error ) ) {
                 continue;
             }
 
-            $mismatchDescription->appendText('there was parsing error: ')
-                ->appendText(trim($error->message))
-                ->appendText(' on line ')
-                ->appendText($error->line);
+            $mismatchDescription->appendText( 'there was parsing error: ' )
+                ->appendText( trim( $error->message ) )
+                ->appendText( ' on line ' )
+                ->appendText( $error->line );
             $result = false;
         }
 
-        if ($result === false) {
+        if ( $result === false ) {
             return $result;
         }
-        $mismatchDescription->appendText('valid html piece ');
+        $mismatchDescription->appendText( 'valid html piece ' );
 
-        if ($this->elementMatcher) {
-            $result = $this->elementMatcher->matches($document);
-            $this->elementMatcher->describeMismatch($document, $mismatchDescription);
+        if ( $this->elementMatcher ) {
+            $result = $this->elementMatcher->matches( $document );
+            $this->elementMatcher->describeMismatch( $document, $mismatchDescription );
         }
 
-        $mismatchDescription->appendText("\nActual html:\n")->appendText($html);
+        $mismatchDescription->appendText( "\nActual html:\n" )->appendText( $html );
 
         return $result;
     }
 
-    private function isUnknownTagError(\LibXMLError $error)
-    {
+    private function isUnknownTagError( \LibXMLError $error ) {
         return $error->code === self::XML_UNKNOWN_TAG_ERROR_CODE;
     }
 
@@ -98,11 +92,10 @@ class HtmlMatcher extends DiagnosingMatcher
      *
      * @return string HTML
      */
-    private function escapeScriptTagContents($html)
-    {
-        return preg_replace_callback('#(<script.*>)(.*)(</script>)#isU', function ($matches) {
-            return $matches[1] . str_replace('</', '<\/', $matches[2]) . $matches[3];
-        }, $html);
+    private function escapeScriptTagContents( $html ) {
+        return preg_replace_callback( '#(<script.*>)(.*)(</script>)#isU', function ( $matches ) {
+            return $matches[1] . str_replace( '</', '<\/', $matches[2] ) . $matches[3];
+        }, $html );
     }
 
 }

--- a/src/RootElementMatcher.php
+++ b/src/RootElementMatcher.php
@@ -6,8 +6,7 @@ use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\TypeSafeDiagnosingMatcher;
 
-class RootElementMatcher extends TypeSafeDiagnosingMatcher
-{
+class RootElementMatcher extends TypeSafeDiagnosingMatcher {
 
     /**
      * @var Matcher
@@ -19,21 +18,19 @@ class RootElementMatcher extends TypeSafeDiagnosingMatcher
      *
      * @return static
      */
-    public static function havingRootElement(Matcher $tagMatcher = null) {
-        return new static($tagMatcher);
+    public static function havingRootElement( Matcher $tagMatcher = null ) {
+        return new static( $tagMatcher );
     }
 
-    public function __construct(Matcher $tagMatcher = null)
-    {
-        parent::__construct(self::TYPE_OBJECT, \DOMDocument::class);
+    public function __construct( Matcher $tagMatcher = null ) {
+        parent::__construct( self::TYPE_OBJECT, \DOMDocument::class );
         $this->tagMatcher = $tagMatcher;
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('having root element ');
-        if ($this->tagMatcher) {
-            $description->appendDescriptionOf($this->tagMatcher);
+    public function describeTo( Description $description ) {
+        $description->appendText( 'having root element ' );
+        if ( $this->tagMatcher ) {
+            $description->appendDescriptionOf( $this->tagMatcher );
         }
     }
 
@@ -43,28 +40,27 @@ class RootElementMatcher extends TypeSafeDiagnosingMatcher
      *
      * @return bool
      */
-    protected function matchesSafelyWithDiagnosticDescription($item, Description $mismatchDescription)
-    {
-        $DOMNodeList = iterator_to_array($item->documentElement->childNodes);
+    protected function matchesSafelyWithDiagnosticDescription( $item, Description $mismatchDescription ) {
+        $DOMNodeList = iterator_to_array( $item->documentElement->childNodes );
 
-        $body = array_shift($DOMNodeList);
-        $DOMNodeList = iterator_to_array($body->childNodes);
-        if (count($DOMNodeList) > 1) {
+        $body = array_shift( $DOMNodeList );
+        $DOMNodeList = iterator_to_array( $body->childNodes );
+        if ( count( $DOMNodeList ) > 1 ) {
             //TODO Test this description
-            $mismatchDescription->appendText('having ' . count($DOMNodeList) . ' root elements ');
+            $mismatchDescription->appendText( 'having ' . count( $DOMNodeList ) . ' root elements ' );
             return false;
         }
 
-        $target = array_shift($DOMNodeList);
-        if (!$target) {
+        $target = array_shift( $DOMNodeList );
+        if ( !$target ) {
             //TODO Reproduce?
-            $mismatchDescription->appendText('having no root elements ');
+            $mismatchDescription->appendText( 'having no root elements ' );
             return false;
         }
-        if ($this->tagMatcher) {
-            $mismatchDescription->appendText('root element ');
-            $this->tagMatcher->describeMismatch($target, $mismatchDescription);
-            return $this->tagMatcher->matches($target);
+        if ( $this->tagMatcher ) {
+            $mismatchDescription->appendText( 'root element ' );
+            $this->tagMatcher->describeMismatch( $target, $mismatchDescription );
+            return $this->tagMatcher->matches( $target );
         }
 
         return (bool)$target;

--- a/src/TagMatcher.php
+++ b/src/TagMatcher.php
@@ -4,12 +4,10 @@ namespace WMDE\HamcrestHtml;
 
 use Hamcrest\TypeSafeDiagnosingMatcher;
 
-abstract class TagMatcher extends TypeSafeDiagnosingMatcher
-{
+abstract class TagMatcher extends TypeSafeDiagnosingMatcher {
 
-    public function __construct()
-    {
-        parent::__construct(self::TYPE_OBJECT, \DOMElement::class);
+    public function __construct() {
+        parent::__construct( self::TYPE_OBJECT, \DOMElement::class );
     }
 
 }

--- a/src/TagNameMatcher.php
+++ b/src/TagNameMatcher.php
@@ -6,28 +6,25 @@ use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\Util;
 
-class TagNameMatcher extends TagMatcher
-{
+class TagNameMatcher extends TagMatcher {
 
     /**
      * @var Matcher
      */
     private $tagNameMatcher;
 
-    public static function withTagName($tagName) {
-        return new static(Util::wrapValueWithIsEqual($tagName));
+    public static function withTagName( $tagName ) {
+        return new static( Util::wrapValueWithIsEqual( $tagName ) );
     }
 
-    public function __construct(Matcher $tagNameMatcher)
-    {
+    public function __construct( Matcher $tagNameMatcher ) {
         parent::__construct();
         $this->tagNameMatcher = $tagNameMatcher;
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('with tag name ')
-            ->appendDescriptionOf($this->tagNameMatcher);
+    public function describeTo( Description $description ) {
+        $description->appendText( 'with tag name ' )
+            ->appendDescriptionOf( $this->tagNameMatcher );
     }
 
     /**
@@ -36,11 +33,10 @@ class TagNameMatcher extends TagMatcher
      *
      * @return bool
      */
-    protected function matchesSafelyWithDiagnosticDescription($item, Description $mismatchDescription)
-    {
-        $mismatchDescription->appendText('tag name ');
-        $this->tagNameMatcher->describeMismatch($item->tagName, $mismatchDescription);
-        return $this->tagNameMatcher->matches($item->tagName);
+    protected function matchesSafelyWithDiagnosticDescription( $item, Description $mismatchDescription ) {
+        $mismatchDescription->appendText( 'tag name ' );
+        $this->tagNameMatcher->describeMismatch( $item->tagName, $mismatchDescription );
+        return $this->tagNameMatcher->matches( $item->tagName );
     }
 
 }

--- a/src/TextContentsMatcher.php
+++ b/src/TextContentsMatcher.php
@@ -6,27 +6,24 @@ use Hamcrest\Description;
 use Hamcrest\Matcher;
 use Hamcrest\Util;
 
-class TextContentsMatcher extends TagMatcher
-{
+class TextContentsMatcher extends TagMatcher {
 
     /**
      * @var Matcher
      */
     private $matcher;
 
-    public static function havingTextContents($text) {
-        return new static(Util::wrapValueWithIsEqual($text));
+    public static function havingTextContents( $text ) {
+        return new static( Util::wrapValueWithIsEqual( $text ) );
     }
 
-    public function __construct(Matcher $matcher)
-    {
+    public function __construct( Matcher $matcher ) {
         parent::__construct();
         $this->matcher = $matcher;
     }
 
-    public function describeTo(Description $description)
-    {
-        $description->appendText('having text contents ')->appendDescriptionOf($this->matcher);
+    public function describeTo( Description $description ) {
+        $description->appendText( 'having text contents ' )->appendDescriptionOf( $this->matcher );
     }
 
     /**
@@ -35,9 +32,8 @@ class TextContentsMatcher extends TagMatcher
      *
      * @return bool
      */
-    protected function matchesSafelyWithDiagnosticDescription($item, Description $mismatchDescription)
-    {
-        return $this->matcher->matches($item->textContent);
+    protected function matchesSafelyWithDiagnosticDescription( $item, Description $mismatchDescription ) {
+        return $this->matcher->matches( $item->textContent );
     }
 
 }

--- a/src/XmlNodeRecursiveIterator.php
+++ b/src/XmlNodeRecursiveIterator.php
@@ -2,13 +2,11 @@
 
 namespace WMDE\HamcrestHtml;
 
-class XmlNodeRecursiveIterator extends \ArrayIterator
-{
+class XmlNodeRecursiveIterator extends \ArrayIterator {
 
-    public function __construct(\DOMNodeList $nodeList)
-    {
-        $queue = $this->addElementsToQueue([], $nodeList);
-        parent::__construct($queue);
+    public function __construct( \DOMNodeList $nodeList ) {
+        $queue = $this->addElementsToQueue( [], $nodeList );
+        parent::__construct( $queue );
     }
 
     /**
@@ -17,13 +15,12 @@ class XmlNodeRecursiveIterator extends \ArrayIterator
      *
      * @return array New queue
      */
-    private function addElementsToQueue(array $queue, \DOMNodeList $nodeList)
-    {
+    private function addElementsToQueue( array $queue, \DOMNodeList $nodeList ) {
         /** @var \DOMElement $node */
-        foreach ($nodeList as $node) {
+        foreach ( $nodeList as $node ) {
             $queue[] = $node;
-            if ($node->childNodes !== null) {
-                $queue = $this->addElementsToQueue($queue, $node->childNodes);
+            if ( $node->childNodes !== null ) {
+                $queue = $this->addElementsToQueue( $queue, $node->childNodes );
             }
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,88 +2,88 @@
 
 use Hamcrest\Matcher;
 
-if (!function_exists('htmlPiece')) {
+if ( !function_exists( 'htmlPiece' ) ) {
     /**
      * @param mixed $elementMatcher
      *
      * @return \WMDE\HamcrestHtml\HtmlMatcher
      */
-    function htmlPiece(Matcher $elementMatcher = null) {
-        return \WMDE\HamcrestHtml\HtmlMatcher::htmlPiece($elementMatcher);
+    function htmlPiece( Matcher $elementMatcher = null ) {
+        return \WMDE\HamcrestHtml\HtmlMatcher::htmlPiece( $elementMatcher );
     }
 }
 
-if (!function_exists('havingRootElement')) {
-    function havingRootElement(Matcher $matcher = null) {
-        return \WMDE\HamcrestHtml\RootElementMatcher::havingRootElement($matcher);
+if ( !function_exists( 'havingRootElement' ) ) {
+    function havingRootElement( Matcher $matcher = null ) {
+        return \WMDE\HamcrestHtml\RootElementMatcher::havingRootElement( $matcher );
     }
 }
 
-if (!function_exists('havingDirectChild')) {
-    function havingDirectChild(Matcher $elementMatcher = null) {
-        return \WMDE\HamcrestHtml\DirectChildElementMatcher::havingDirectChild($elementMatcher);
+if ( !function_exists( 'havingDirectChild' ) ) {
+    function havingDirectChild( Matcher $elementMatcher = null ) {
+        return \WMDE\HamcrestHtml\DirectChildElementMatcher::havingDirectChild( $elementMatcher );
     }
 }
 
-if (!function_exists('havingChild')) {
-    function havingChild(Matcher $elementMatcher = null) {
-        return \WMDE\HamcrestHtml\ChildElementMatcher::havingChild($elementMatcher);
+if ( !function_exists( 'havingChild' ) ) {
+    function havingChild( Matcher $elementMatcher = null ) {
+        return \WMDE\HamcrestHtml\ChildElementMatcher::havingChild( $elementMatcher );
     }
 }
 
-if (!function_exists('withTagName')) {
+if ( !function_exists( 'withTagName' ) ) {
     /**
      * @param Matcher|string $tagName
      *
      * @return \WMDE\HamcrestHtml\TagNameMatcher
      */
-    function withTagName($tagName) {
-        return \WMDE\HamcrestHtml\TagNameMatcher::withTagName($tagName);
+    function withTagName( $tagName ) {
+        return \WMDE\HamcrestHtml\TagNameMatcher::withTagName( $tagName );
     }
 }
 
-if (!function_exists('withAttribute')) {
+if ( !function_exists( 'withAttribute' ) ) {
     /**
      * @param Matcher|string $attributeName
      *
      * @return \WMDE\HamcrestHtml\AttributeMatcher
      */
-    function withAttribute($attributeName) {
-        return \WMDE\HamcrestHtml\AttributeMatcher::withAttribute($attributeName);
+    function withAttribute( $attributeName ) {
+        return \WMDE\HamcrestHtml\AttributeMatcher::withAttribute( $attributeName );
     }
 }
 
-if (!function_exists('withClass')) {
+if ( !function_exists( 'withClass' ) ) {
     /**
      * @param Matcher|string $class
      *
      * @return \WMDE\HamcrestHtml\ClassMatcher
      */
-    function withClass($class) {
+    function withClass( $class ) {
         //TODO don't allow to call with empty string
 
-        return \WMDE\HamcrestHtml\ClassMatcher::withClass($class);
+        return \WMDE\HamcrestHtml\ClassMatcher::withClass( $class );
     }
 }
 
-if (!function_exists('havingTextContents')) {
+if ( !function_exists( 'havingTextContents' ) ) {
     /**
      * @param Matcher|string $text
      *
      * @return \WMDE\HamcrestHtml\TextContentsMatcher
      */
-    function havingTextContents($text) {
-        return \WMDE\HamcrestHtml\TextContentsMatcher::havingTextContents($text);
+    function havingTextContents( $text ) {
+        return \WMDE\HamcrestHtml\TextContentsMatcher::havingTextContents( $text );
     }
 }
 
-if (!function_exists('tagMatchingOutline')) {
+if ( !function_exists( 'tagMatchingOutline' ) ) {
     /**
      * @param string $htmlOutline
      *
      * @return \WMDE\HamcrestHtml\ComplexTagMatcher
      */
-    function tagMatchingOutline($htmlOutline) {
-        return \WMDE\HamcrestHtml\ComplexTagMatcher::tagMatchingOutline($htmlOutline);
+    function tagMatchingOutline( $htmlOutline ) {
+        return \WMDE\HamcrestHtml\ComplexTagMatcher::tagMatchingOutline( $htmlOutline );
     }
 }

--- a/tests/ComplexTagMatcherTest.php
+++ b/tests/ComplexTagMatcherTest.php
@@ -8,8 +8,7 @@ use WMDE\HamcrestHtml\ComplexTagMatcher;
 /**
  * @covers WMDE\HamcrestHtml\ComplexTagMatcher
  */
-class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
-{
+class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @test
@@ -17,7 +16,7 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertPasses_WhenTagInHtmlHasSameTagName() {
         $html = '<p></p>';
 
-        assertThat($html, is(htmlPiece(havingChild(ComplexTagMatcher::tagMatchingOutline('<p/>')))));
+        assertThat( $html, is( htmlPiece( havingChild( ComplexTagMatcher::tagMatchingOutline( '<p/>' ) ) ) ) );
     }
 
     /**
@@ -26,32 +25,32 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertFails_WhenTagInHtmlIsDiffersFromGivenTagName() {
         $html = '<a></a>';
 
-        $this->setExpectedException(AssertionError::class);
-        assertThat($html, is(htmlPiece(havingChild(ComplexTagMatcher::tagMatchingOutline('<p/>')))));
+        $this->setExpectedException( AssertionError::class );
+        assertThat( $html, is( htmlPiece( havingChild( ComplexTagMatcher::tagMatchingOutline( '<p/>' ) ) ) ) );
     }
 
     /**
      * @test
      */
     public function canNotCreateMatcherWithEmptyDescription() {
-        $this->setExpectedException(\Exception::class);
-        ComplexTagMatcher::tagMatchingOutline('');
+        $this->setExpectedException( \Exception::class );
+        ComplexTagMatcher::tagMatchingOutline( '' );
     }
 
     /**
      * @test
      */
     public function canNotCreateMatcherExpectingTwoElements() {
-        $this->setExpectedException(\Exception::class);
-        ComplexTagMatcher::tagMatchingOutline('<p></p><b></b>');
+        $this->setExpectedException( \Exception::class );
+        ComplexTagMatcher::tagMatchingOutline( '<p></p><b></b>' );
     }
 
     /**
      * @test
      */
     public function canNotCreateMatcherWithChildElement() {
-        $this->setExpectedException(\Exception::class);
-        ComplexTagMatcher::tagMatchingOutline('<p><b></b></p>');
+        $this->setExpectedException( \Exception::class );
+        ComplexTagMatcher::tagMatchingOutline( '<p><b></b></p>' );
     }
 
     /**
@@ -60,9 +59,9 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertFails_WhenTagInHtmlDoesNotHaveExpectedAttribute() {
         $html = '<p></p>';
 
-        $this->setExpectedException(AssertionError::class);
-        assertThat($html, is(htmlPiece(havingChild(
-            ComplexTagMatcher::tagMatchingOutline('<p id="some-id"/>')))));
+        $this->setExpectedException( AssertionError::class );
+        assertThat( $html, is( htmlPiece( havingChild(
+            ComplexTagMatcher::tagMatchingOutline( '<p id="some-id"/>' ) ) ) ) );
     }
 
     /**
@@ -71,8 +70,8 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertPasses_WhenTagInHtmlHasExpectedAttribute() {
         $html = '<p id="some-id"></p>';
 
-        assertThat($html, is(htmlPiece(havingChild(
-            ComplexTagMatcher::tagMatchingOutline('<p id="some-id"/>')))));
+        assertThat( $html, is( htmlPiece( havingChild(
+            ComplexTagMatcher::tagMatchingOutline( '<p id="some-id"/>' ) ) ) ) );
     }
 
     /**
@@ -81,9 +80,9 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertFails_WhenTagInHtmlDoesNotHaveAllExpectedAttribute() {
         $html = '<p id="some-id"></p>';
 
-        $this->setExpectedException(AssertionError::class);
-        assertThat($html, is(htmlPiece(havingChild(
-            ComplexTagMatcher::tagMatchingOutline('<p id="some-id" onclick="void();"/>')))));
+        $this->setExpectedException( AssertionError::class );
+        assertThat( $html, is( htmlPiece( havingChild(
+            ComplexTagMatcher::tagMatchingOutline( '<p id="some-id" onclick="void();"/>' ) ) ) ) );
     }
 
     /**
@@ -92,8 +91,8 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertPasses_WhenExpectBooleanAttributeButItIsThereWithSomeValue() {
         $html = '<input required="anything">';
 
-        assertThat($html, is(htmlPiece(havingChild(
-            ComplexTagMatcher::tagMatchingOutline('<input required/>')))));
+        assertThat( $html, is( htmlPiece( havingChild(
+            ComplexTagMatcher::tagMatchingOutline( '<input required/>' ) ) ) ) );
     }
 
     /**
@@ -102,9 +101,9 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertFails_WhenExpectAttributeWithEmptyValueButItIsNotEmpty() {
         $html = '<input attr1="something">';
 
-        $this->setExpectedException(AssertionError::class);
-        assertThat($html, is(htmlPiece(havingChild(
-            ComplexTagMatcher::tagMatchingOutline('<input attr1=""/>')))));
+        $this->setExpectedException( AssertionError::class );
+        assertThat( $html, is( htmlPiece( havingChild(
+            ComplexTagMatcher::tagMatchingOutline( '<input attr1=""/>' ) ) ) ) );
     }
 
     /**
@@ -113,8 +112,8 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertPasses_WhenGivenTagHasExpectedClass() {
         $html = '<input class="class1 class2">';
 
-        assertThat($html, is(htmlPiece(havingChild(
-            ComplexTagMatcher::tagMatchingOutline('<input class="class2"/>')))));
+        assertThat( $html, is( htmlPiece( havingChild(
+            ComplexTagMatcher::tagMatchingOutline( '<input class="class2"/>' ) ) ) ) );
     }
 
     /**
@@ -123,9 +122,9 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function assertFails_WhenGivenTagDoesNotHaveExpectedClass() {
         $html = '<input class="class1 class2">';
 
-        $this->setExpectedException(AssertionError::class);
-        assertThat($html, is(htmlPiece(havingChild(
-            ComplexTagMatcher::tagMatchingOutline('<input class="class3"/>')))));
+        $this->setExpectedException( AssertionError::class );
+        assertThat( $html, is( htmlPiece( havingChild(
+            ComplexTagMatcher::tagMatchingOutline( '<input class="class3"/>' ) ) ) ) );
     }
 
     /**
@@ -134,8 +133,8 @@ class ComplexTagMatcherTest extends \PHPUnit_Framework_TestCase
     public function toleratesExtraSpacesInClassDescription() {
         $html = '<input class="class1">';
 
-        assertThat($html, is(htmlPiece(havingChild(
-            ComplexTagMatcher::tagMatchingOutline('<input class="   class1   "/>')))));
+        assertThat( $html, is( htmlPiece( havingChild(
+            ComplexTagMatcher::tagMatchingOutline( '<input class="   class1   "/>' ) ) ) ) );
     }
 
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -5,47 +5,44 @@ namespace WMDE\HamcrestHtml\Test;
 use Hamcrest\AssertionError;
 use Hamcrest\Matcher;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase
-{
+class FunctionsTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @test
      */
-    public function havingRootElement_MultipleRootTags_ThrowsException()
-    {
+    public function havingRootElement_MultipleRootTags_ThrowsException() {
         //TODO Does it make sense?
         $html = '<p></p><p></p>';
 
-        $this->setExpectedException(AssertionError::class);
-        assertThat($html, is(htmlPiece(havingRootElement())));
+        $this->setExpectedException( AssertionError::class );
+        assertThat( $html, is( htmlPiece( havingRootElement() ) ) );
     }
 
     /**
      * @test
      * @dataProvider dataProvider_ElementExists
      */
-    public function matcherCanFindElement($html, $matcher) {
-        assertThat($html, is(htmlPiece($matcher)));
+    public function matcherCanFindElement( $html, $matcher ) {
+        assertThat( $html, is( htmlPiece( $matcher ) ) );
     }
 
     /**
      * @test
      * @dataProvider dataProvider_ElementDoesNotExist
      */
-    public function matcherCantFindElement($html, $matcher, Matcher $messageMatcher) {
+    public function matcherCantFindElement( $html, $matcher, Matcher $messageMatcher ) {
         $thrownException = null;
         try {
-            assertThat($html, is(htmlPiece($matcher)));
-        } catch (\Exception $e) {
+            assertThat( $html, is( htmlPiece( $matcher ) ) );
+        } catch ( \Exception $e ) {
             $thrownException = $e;
         }
 
-        assertThat($thrownException, is(anInstanceOf(AssertionError::class)));
-        assertThat($thrownException->getMessage(), $messageMatcher);
+        assertThat( $thrownException, is( anInstanceOf( AssertionError::class ) ) );
+        assertThat( $thrownException->getMessage(), $messageMatcher );
     }
 
-    public function dataProvider_ElementExists()
-    {
+    public function dataProvider_ElementExists() {
         return [
             'htmlPiece - simple case' => [
                 '<p></p>',
@@ -57,7 +54,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
             ],
             'withTagName - simple case' => [
                 '<p><b></b></p>',
-                havingRootElement(withTagName('p'))
+                havingRootElement( withTagName( 'p' ) )
             ],
             'havingDirectChild - without qualifier' => [
                 '<p></p>',
@@ -65,136 +62,135 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
             ],
             'havingDirectChild - nested structure' => [
                 '<p><b></b></p>',
-                havingDirectChild(havingDirectChild(withTagName('b')))
+                havingDirectChild( havingDirectChild( withTagName( 'b' ) ) )
             ],
             'havingChild - target tag is not first' => [
                 '<i></i><b></b>',
-                havingChild(withTagName('b'))
+                havingChild( withTagName( 'b' ) )
             ],
             'havingChild - target tag is nested' => [
                 '<p><b><i></i></b></p>',
-                havingChild(withTagName('i'))
+                havingChild( withTagName( 'i' ) )
             ],
             'withAttribute - select element by attribute name only' => [
                 '<p><input name="something"/></p>',
-                havingChild(withAttribute('name'))
+                havingChild( withAttribute( 'name' ) )
             ],
             'withAttribute - select element by attribute name and value' => [
                 '<p><input name="something"/></p>',
-                havingChild(withAttribute('name')->havingValue('something'))
+                havingChild( withAttribute( 'name' )->havingValue( 'something' ) )
             ],
             'withClass - exact match' => [
                 '<p class="test-class"></p>',
-                havingChild(withClass('test-class'))
+                havingChild( withClass( 'test-class' ) )
             ],
             'withClass - one of the classes' => [
                 '<p class="class1 class2 class3"></p>',
-                havingChild(withClass('class2'))
+                havingChild( withClass( 'class2' ) )
             ],
             'withClass - classes separated with tab' => [
                 "<p class='class1\tclass2\tclass3'></p>",
-                havingChild(withClass('class2'))
+                havingChild( withClass( 'class2' ) )
             ],
             'havingTextContents' => [
                 '<p>this is some text</p>',
-                havingChild(havingTextContents(containsString('some text')))
+                havingChild( havingTextContents( containsString( 'some text' ) ) )
             ],
             'havingTextContents - unicode text' => [
                 '<p>какой-то текст</p>',
-                havingChild(havingTextContents(containsString('какой-то текст')))
+                havingChild( havingTextContents( containsString( 'какой-то текст' ) ) )
             ],
             'tagMatchingOutline' => [
                 '<form><input id="ip-password" class="pretty important" name="password"></form>',
-                havingChild(tagMatchingOutline('<input name="password" class="important">'))
+                havingChild( tagMatchingOutline( '<input name="password" class="important">' ) )
             ],
         ];
     }
 
-    public function dataProvider_ElementDoesNotExist()
-    {
+    public function dataProvider_ElementDoesNotExist() {
         return [
             'htmlPiece - messed up tags' => [
                 '<p><a></p></a>',
                 null,
-                allOf(containsString('html piece'), containsString('there was parsing error'))
+                allOf( containsString( 'html piece' ), containsString( 'there was parsing error' ) )
             ],
             'htmlPiece - prints passed html on failure' => [
                 '<p><a></a></p>',
-                havingRootElement(withTagName('b')),
-                containsString('<p><a></a></p>')
+                havingRootElement( withTagName( 'b' ) ),
+                containsString( '<p><a></a></p>' )
             ],
             'withTagName - simple case' => [
                 '<p><b></b></p>',
-                havingRootElement(withTagName('b')),
-                allOf(containsString('having root element'),
-                    containsString('with tag name "b"'),
-                    containsString('root element tag name was "p"')),
+                havingRootElement( withTagName( 'b' ) ),
+                allOf( containsString( 'having root element' ),
+                    containsString( 'with tag name "b"' ),
+                    containsString( 'root element tag name was "p"' ) ),
             ],
             'havingDirectChild - no direct child' => [
                 '<p></p>',
-                havingDirectChild(havingDirectChild()),
-                allOf(containsString('having direct child'),
-                    containsString('with direct child with no direct children')),
+                havingDirectChild( havingDirectChild() ),
+                allOf( containsString( 'having direct child' ),
+                    containsString( 'with direct child with no direct children' ) ),
             ],
             'havingDirectChild - single element' => [
                 '<p></p>',
-                havingDirectChild(withTagName('b')),
-                allOf(containsString('having direct child'),
-                    containsString('with tag name "b"')),
+                havingDirectChild( withTagName( 'b' ) ),
+                allOf( containsString( 'having direct child' ),
+                    containsString( 'with tag name "b"' ) ),
             ],
             'havingDirectChild - nested matcher' => [
                 '<p><b></b></p>',
-                havingDirectChild(havingDirectChild(withTagName('p'))),
-                both(containsString('having direct child having direct child with tag name "p"'))
-                    ->andAlso(containsString('direct child with direct child tag name was "b"'))
+                havingDirectChild( havingDirectChild( withTagName( 'p' ) ) ),
+                both( containsString( 'having direct child having direct child with tag name "p"' ) )
+                    ->andAlso( containsString( 'direct child with direct child tag name was "b"' ) )
             ],
             'havingChild - no children' => [
                 '<p></p>',
-                havingDirectChild(havingChild()),
-                both(containsString('having direct child having child'))
-                    ->andAlso(containsString('having no children'))
+                havingDirectChild( havingChild() ),
+                both( containsString( 'having direct child having child' ) )
+                    ->andAlso( containsString( 'having no children' ) )
             ],
             'havingChild - target tag is absent' => [
                 '<p><b><i></i></b></p>',
-                havingChild(withTagName('br')),
-                both(containsString('having child with tag name "br"'))
-                    ->andAlso(containsString('having no children with tag name "br"'))
+                havingChild( withTagName( 'br' ) ),
+                both( containsString( 'having child with tag name "br"' ) )
+                    ->andAlso( containsString( 'having no children with tag name "br"' ) )
             ],
 
             'withAttribute - select element by attribute name only' => [
                 '<p><input name="something"/></p>',
-                havingChild(withAttribute('value')),
-                both(containsString('having child with attribute "value"'))
-                    ->andAlso(containsString('having no children with attribute "value"'))
+                havingChild( withAttribute( 'value' ) ),
+                both( containsString( 'having child with attribute "value"' ) )
+                    ->andAlso( containsString( 'having no children with attribute "value"' ) )
             ],
             'withAttribute - select element by attribute name and value' => [
                 '<p><input name="something-else"/></p>',
-                havingChild(withAttribute('name')->havingValue('something')),
-                both(containsString('having child with attribute "name" having value "something"'))
-                    ->andAlso(containsString('having no children with attribute "name" having value "something"'))
+                havingChild( withAttribute( 'name' )->havingValue( 'something' ) ),
+                both( containsString( 'having child with attribute "name" having value "something"' ) )
+                    ->andAlso( containsString( 'having no children with attribute "name" having value "something"' ) )
             ],
             'withClass - no class' => [
                 '<p></p>',
-                havingChild(withClass('test-class')),
-                both(containsString('having child with class "test-class"'))
-                    ->andAlso(containsString('having no children with class "test-class"'))
+                havingChild( withClass( 'test-class' ) ),
+                both( containsString( 'having child with class "test-class"' ) )
+                    ->andAlso( containsString( 'having no children with class "test-class"' ) )
             ],
             'havingTextContents' => [
                 '<div><p>this is some text</p></div>',
-                havingChild(havingTextContents('this is another text')),
-                both(containsString('having child having text contents "this is another text"'))
-                    ->andAlso(containsString('no children having text contents "this is another text"'))
+                havingChild( havingTextContents( 'this is another text' ) ),
+                both( containsString( 'having child having text contents "this is another text"' ) )
+                    ->andAlso( containsString( 'no children having text contents "this is another text"' ) )
             ],
             'havingTextContents - does not respect text in comments;' => [
                 '<div><!--commented text--></div>',
-                havingChild(havingTextContents('commented text')),
+                havingChild( havingTextContents( 'commented text' ) ),
                 anything()
             ],
             'tagMatchingOutline' => [
                 '<input id="ip-password" class="pretty">',
-                havingRootElement(tagMatchingOutline('<input name="password" class="important">')),
-                both(containsString('matching outline `<input name="password" class="important">`'))
-                    ->andAlso(containsString('was `<input id="ip-password" class="pretty">`'))
+                havingRootElement( tagMatchingOutline( '<input name="password" class="important">' ) ),
+                both( containsString( 'matching outline `<input name="password" class="important">`' ) )
+                    ->andAlso( containsString( 'was `<input id="ip-password" class="pretty">`' ) )
             ],
         ];
     }

--- a/tests/HtmlMatcherTest.php
+++ b/tests/HtmlMatcherTest.php
@@ -7,103 +7,97 @@ use WMDE\HamcrestHtml\HtmlMatcher;
 /**
  * @covers WMDE\HamcrestHtml\HtmlMatcher
  */
-class HtmlMatcherTest extends \PHPUnit_Framework_TestCase
-{
+class HtmlMatcherTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @test
      * @dataProvider dataProvider_HtmlTagNamesIntroducedInHtml5
      */
-    public function considersValidHtml_WhenUnknownForHtmlParserTagIsGiven($tagIntroducedInHtml5)
-    {
+    public function considersValidHtml_WhenUnknownForHtmlParserTagIsGiven( $tagIntroducedInHtml5 ) {
         $html = "<$tagIntroducedInHtml5></$tagIntroducedInHtml5>";
 
-        assertThat($html, is(HtmlMatcher::htmlPiece()));
+        assertThat( $html, is( HtmlMatcher::htmlPiece() ) );
     }
 
-    public function dataProvider_HtmlTagNamesIntroducedInHtml5()
-    {
+    public function dataProvider_HtmlTagNamesIntroducedInHtml5() {
         return [
-            'article' => ['article'],
-            'aside' => ['aside'],
-            'bdi' => ['bdi'],
-            'details' => ['details'],
-            'dialog' => ['dialog'],
-            'figcaption' => ['figcaption'],
-            'figure' => ['figure'],
-            'footer' => ['footer'],
-            'header' => ['header'],
-            'main' => ['main'],
-            'mark' => ['mark'],
-            'menuitem' => ['menuitem'],
-            'meter' => ['meter'],
-            'nav' => ['nav'],
-            'progress' => ['progress'],
-            'rp' => ['rp'],
-            'rt' => ['rt'],
-            'ruby' => ['ruby'],
-            'section' => ['section'],
-            'summary' => ['summary'],
-            'time' => ['time'],
-            'wbr' => ['wbr'],
-            'datalist' => ['datalist'],
-            'keygen' => ['keygen'],
-            'output' => ['output'],
-            'canvas' => ['canvas'],
-            'svg' => ['svg'],
-            'audio' => ['audio'],
-            'embed' => ['embed'],
-            'source' => ['source'],
-            'track' => ['track'],
-            'video' => ['video'],
+            'article' => [ 'article' ],
+            'aside' => [ 'aside' ],
+            'bdi' => [ 'bdi' ],
+            'details' => [ 'details' ],
+            'dialog' => [ 'dialog' ],
+            'figcaption' => [ 'figcaption' ],
+            'figure' => [ 'figure' ],
+            'footer' => [ 'footer' ],
+            'header' => [ 'header' ],
+            'main' => [ 'main' ],
+            'mark' => [ 'mark' ],
+            'menuitem' => [ 'menuitem' ],
+            'meter' => [ 'meter' ],
+            'nav' => [ 'nav' ],
+            'progress' => [ 'progress' ],
+            'rp' => [ 'rp' ],
+            'rt' => [ 'rt' ],
+            'ruby' => [ 'ruby' ],
+            'section' => [ 'section' ],
+            'summary' => [ 'summary' ],
+            'time' => [ 'time' ],
+            'wbr' => [ 'wbr' ],
+            'datalist' => [ 'datalist' ],
+            'keygen' => [ 'keygen' ],
+            'output' => [ 'output' ],
+            'canvas' => [ 'canvas' ],
+            'svg' => [ 'svg' ],
+            'audio' => [ 'audio' ],
+            'embed' => [ 'embed' ],
+            'source' => [ 'source' ],
+            'track' => [ 'track' ],
+            'video' => [ 'video' ],
         ];
     }
 
     /**
      * @test
      */
-    public function considersValidHtml_WHtmlContainsScriptTagWithHtmlContents()
-    {
+    public function considersValidHtml_WHtmlContainsScriptTagWithHtmlContents() {
         $html = "<div>
 <script type='x-template'>
-	<span></span>
+    <span></span>
 </script>
 </div>";
 
-        assertThat($html, is(HtmlMatcher::htmlPiece()));
+        assertThat( $html, is( HtmlMatcher::htmlPiece() ) );
     }
 
     /**
      * @test
      */
-    public function addsSpecificTextInsideTheScriptTagsInsteadOfItsContents()
-    {
+    public function addsSpecificTextInsideTheScriptTagsInsteadOfItsContents() {
         $html = "<div>
 <script type='x-template'><span></span></script>
 </div>";
 
-        assertThat($html, is(htmlPiece(havingChild(
-            both(withTagName('script'))
-                ->andAlso(havingTextContents("<span><\\/span>"))))));
+        assertThat( $html, is( htmlPiece( havingChild(
+            both( withTagName( 'script' ) )
+                ->andAlso( havingTextContents( '<span><\/span>' ) ) ) ) ) );
     }
 
     /**
      * @test
      */
-    public function doesNotTouchScriptTagAttributes()
-    {
+    public function doesNotTouchScriptTagAttributes() {
         $html = "<div>
 <script type='x-template' attr1='value1'>
-	<span></span>
+    <span></span>
 </script>
 </div>";
 
-        assertThat($html, is(htmlPiece(havingChild(
+        assertThat( $html, is( htmlPiece( havingChild(
             allOf(
-                withTagName('script'),
-                withAttribute('type')->havingValue('x-template'),
-                withAttribute('attr1')->havingValue('value1')
-            )))));
+                withTagName( 'script' ),
+                withAttribute( 'type' )->havingValue( 'x-template' ),
+                withAttribute( 'attr1' )->havingValue( 'value1' )
+            ) ) ) ) );
     }
 
 }

--- a/tests/XmlNodeRecursiveIteratorTest.php
+++ b/tests/XmlNodeRecursiveIteratorTest.php
@@ -7,43 +7,39 @@ use WMDE\HamcrestHtml\XmlNodeRecursiveIterator;
 /**
  * @covers WMDE\HamcrestHtml\XmlNodeRecursiveIterator
  */
-class XmlNodeRecursiveIteratorTest extends \PHPUnit_Framework_TestCase
-{
+class XmlNodeRecursiveIteratorTest extends \PHPUnit_Framework_TestCase {
 
-    public function testIteratesAllElements_WhenFlatStructureGiven()
-    {
-        $DOMNodeList = $this->createDomNodeListFromHtml('<p></p>');
+    public function testIteratesAllElements_WhenFlatStructureGiven() {
+        $DOMNodeList = $this->createDomNodeListFromHtml( '<p></p>' );
 
-        $recursiveIterator = new XmlNodeRecursiveIterator($DOMNodeList);
+        $recursiveIterator = new XmlNodeRecursiveIterator( $DOMNodeList );
 
-        $tagNames = $this->collectTagNames($recursiveIterator);
-        assertThat($tagNames, is(equalTo(['p'])));
+        $tagNames = $this->collectTagNames( $recursiveIterator );
+        assertThat( $tagNames, is( equalTo( [ 'p' ] ) ) );
     }
 
-    public function testIteratesElementsInAnyOrder_WhenNestedStructureGiven()
-    {
-        $DOMNodeList = $this->createDomNodeListFromHtml('<a1><b1></b1><b2><c21></c21></b2></a1>');
+    public function testIteratesElementsInAnyOrder_WhenNestedStructureGiven() {
+        $DOMNodeList = $this->createDomNodeListFromHtml( '<a1><b1></b1><b2><c21></c21></b2></a1>' );
 
-        $recursiveIterator = new XmlNodeRecursiveIterator($DOMNodeList);
+        $recursiveIterator = new XmlNodeRecursiveIterator( $DOMNodeList );
 
-        $tagNames = $this->collectTagNames($recursiveIterator);
-        assertThat($tagNames, is(containsInAnyOrder('a1', 'b1', 'b2', 'c21')));
+        $tagNames = $this->collectTagNames( $recursiveIterator );
+        assertThat( $tagNames, is( containsInAnyOrder( 'a1', 'b1', 'b2', 'c21' ) ) );
     }
 
-    private function createDomNodeListFromHtml($html)
-    {
-        $internalErrors = libxml_use_internal_errors(true);
+    private function createDomNodeListFromHtml( $html ) {
+        $internalErrors = libxml_use_internal_errors( true );
         $DOMDocument = new \DOMDocument();
 
-        if (!@$DOMDocument->loadHTML($html)) {
-            throw new \RuntimeException('Filed to parse HTML');
+        if ( !@$DOMDocument->loadHTML( $html ) ) {
+            throw new \RuntimeException( 'Filed to parse HTML' );
         }
 
         libxml_clear_errors();
-        libxml_use_internal_errors($internalErrors);
-        $DOMNodeList = iterator_to_array($DOMDocument->documentElement->childNodes);
+        libxml_use_internal_errors( $internalErrors );
+        $DOMNodeList = iterator_to_array( $DOMDocument->documentElement->childNodes );
 
-        $body = array_shift($DOMNodeList);
+        $body = array_shift( $DOMNodeList );
         return $body->childNodes;
     }
 
@@ -51,12 +47,11 @@ class XmlNodeRecursiveIteratorTest extends \PHPUnit_Framework_TestCase
      * @param $recursiveIterator
      * @return array
      */
-    protected function collectTagNames($recursiveIterator)
-    {
-        $array = iterator_to_array($recursiveIterator);
-        $tagNames = array_map(function (\DOMElement $node) {
+    protected function collectTagNames( $recursiveIterator ) {
+        $array = iterator_to_array( $recursiveIterator );
+        $tagNames = array_map( function ( \DOMElement $node ) {
             return $node->tagName;
-        }, $array);
+        }, $array );
         return $tagNames;
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
 /** @var $loader \Composer\Autoload\ClassLoader */
-$loader = require dirname(__DIR__) . '/vendor/autoload.php';
+$loader = require dirname( __DIR__ ) . '/vendor/autoload.php';
 
-require_once dirname(__DIR__) . '/src/functions.php';
+require_once dirname( __DIR__ ) . '/src/functions.php';


### PR DESCRIPTION
This follows #7. I did not updated the indention characters on purpose, otherwise the diff would be a mess. I would like to update this in a later patch.