### PR TITLE
Clear libxml errors before using them

### DIFF
--- a/src/HtmlMatcher.php
+++ b/src/HtmlMatcher.php
@@ -47,6 +47,7 @@ class HtmlMatcher extends DiagnosingMatcher {
 	 */
 	protected function matchesWithDiagnosticDescription( $html, Description $mismatchDescription ) {
 		$internalErrors = libxml_use_internal_errors( true );
+		libxml_clear_errors();
 		$document = new \DOMDocument();
 
 		$html = $this->escapeScriptTagContents( $html );

--- a/tests/HtmlMatcherTest.php
+++ b/tests/HtmlMatcherTest.php
@@ -100,4 +100,15 @@ class HtmlMatcherTest extends \PHPUnit\Framework\TestCase {
 			) ) ) ) );
 	}
 
+    /**
+     * @test
+     */
+    public function considersValidHtml_WhenUnrelatedXMLErrors() {
+        libxml_use_internal_errors( true );
+        $document = new \DOMDocument();
+        $document->loadHTML( 'ThisIsNoHTML<' );
+
+        assertThat( '<html></html>', is( HtmlMatcher::htmlPiece() ) );
+    }
+
 }

--- a/tests/HtmlMatcherTest.php
+++ b/tests/HtmlMatcherTest.php
@@ -100,15 +100,15 @@ class HtmlMatcherTest extends \PHPUnit\Framework\TestCase {
 			) ) ) ) );
 	}
 
-    /**
-     * @test
-     */
-    public function considersValidHtml_WhenUnrelatedXMLErrors() {
-        libxml_use_internal_errors( true );
-        $document = new \DOMDocument();
-        $document->loadHTML( 'ThisIsNoHTML<' );
+	/**
+	 * @test
+	 */
+	public function considersValidHtml_WhenUnrelatedXMLErrors() {
+		libxml_use_internal_errors( true );
+		$document = new \DOMDocument();
+		$document->loadHTML( 'ThisIsNoHTML<' );
 
-        assertThat( '<html></html>', is( HtmlMatcher::htmlPiece() ) );
-    }
+		assertThat( '<html></html>', is( HtmlMatcher::htmlPiece() ) );
+	}
 
 }


### PR DESCRIPTION
In the FileImporter project I got failing hamcrest test due to totally
unrelated leftover libxml errors form other parts of the code. Clearing the
errors before listening and depending on them could be a solution to that.

Although this would not be needed if errors are cleared correctly in other code
places, it was really a pain to debug this.

See
https://gerrit.wikimedia.org/r/#/c/mediawiki/extensions/FileImporter/+/442895/14
https://integration.wikimedia.org/ci/job/quibble-vendor-mysql-hhvm-docker/7215/console
https://gerrit.wikimedia.org/r/#/c/mediawiki/extensions/FileImporter/+/445430/